### PR TITLE
Fixed problem in Redmine initd script

### DIFF
--- a/www-apps/redmine/files/redmine-2.initd
+++ b/www-apps/redmine/files/redmine-2.initd
@@ -33,7 +33,7 @@ start() {
 	cd "${REDMINE_DIR}"
 	start-stop-daemon --start --quiet --user ${REDMINE_USER}:${REDMINE_GROUP} \
 		--pidfile "${REDMINE_PIDFILE}" \
-		--exec /usr/bin/ruby "${REDMINE_DIR}"/script/rails server -- \
+		--exec /usr/bin/ruby "${REDMINE_DIR}"/bin/rails server -- \
 		--daemon --environment=${RAILS_ENV} \
 		--binding=${REDMINE_ADDRESS} --port=${REDMINE_PORT} \
 		--pid="${REDMINE_PIDFILE}" \


### PR DESCRIPTION
Unless script/rails is replaced with bin/rails, the following error message is generated:

    # service redmine start
     * Caching service dependencies ... [ ok ]
     * Starting redmine ...
    script/rails no longer exists, please use bin/rails instead.
     * start-stop-daemon: failed to start `/usr/bin/ruby' [ !! ]
     * ERROR: redmine failed to start